### PR TITLE
Gradle-based dependency solving (for WAILA)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,9 @@ Setup Workspace
 git clone [git-repo-url]
 ```
 
-Download [CodeChickenCore-1.7.2-1.0.0-dev][1], [NotEnoughItems-1.7.2-1.0.1-dev][1] & [Waila-1.5.2a_1.7.2][2]
+If you don't have [Gradle][1] installed on your computer you can use `gradlew` or `gradlew.bat` instead
 
-Add a folder called `libs`, in the folder put the three downloaded `.jar` files.
-
-If you don't have [Gradle][3] installed on your computer you can use `gradlew` or `gradlew.bat` instead
-
-For help setting up a ForgeGradle workspace, go to this [forum page][4].
+For help setting up a ForgeGradle workspace, go to this [forum page][2].
 
 ##### Installing for Intellij IDEA
 ```sh
@@ -28,7 +24,5 @@ gradle setupDecompWorkspace idea
 gradle setupDecompWorkspace eclipse
 ```
 
-[1]:http://www.chickenbones.craftsaddle.org/Files/New_Versions/links.php
-[2]:http://www.minecraftforum.net/topic/1846244-172-
-[3]:http://www.gradle.org/
-[4]:http://www.minecraftforge.net/forum/index.php/topic,14048.0.html
+[1]:http://www.gradle.org/
+[2]:http://www.minecraftforge.net/forum/index.php/topic,14048.0.html

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,21 @@ minecraft {
     assetDir = "eclipse/assets"
 }
 
+repositories {
+    maven { // WAILA
+        name 'Prof. Mobius'
+        url 'http://mobiusstrip.eu/maven'
+    }
+    maven { // NEI and friends
+        name 'Chickenbones'
+        url 'http://chickenbones.net/maven/'
+    }
+}
+
+dependencies {
+    compile 'mcp.mobius.waila:Waila:1.5.5_1.7.10'
+}
+
 processResources
 {
     // this will ensure that this task is redone when the versions change.


### PR DESCRIPTION
That way, you don't have to download a waila jar into a libs folder.
This uses WAILA 1.5.5, which is the latest version that compiles (Mobius changed some stuff)
I may submit a PR later with updates for that
