### PR TITLE
Fixed setting negative numbers in TextBoxNumberList not returning

### DIFF
--- a/src/main/java/vswe/stevesfactory/components/TextBoxNumberList.java
+++ b/src/main/java/vswe/stevesfactory/components/TextBoxNumberList.java
@@ -66,6 +66,7 @@ public class TextBoxNumberList {
             }else if(c == '-' && selectedTextBox.allowNegative()) {
                 selectedTextBox.setNumber(selectedTextBox.getNumber() * -1);
                 selectedTextBox.onNumberChanged();
+                return true;
             }else if(k == 14){
                 selectedTextBox.setNumber(selectedTextBox.getNumber() / 10);
                 selectedTextBox.onNumberChanged();


### PR DESCRIPTION
Fixed not being able to set negative numbers in TextBoxNumberList with GuiManger extend and calling super.onKeyStroke.

An example is by using Steve's Addons, the method is then called twice and setting the value back to the original value.

Bug found when using FTB Infinity Evolved.
